### PR TITLE
Fixed Breaking Change to entrypoint.sh

### DIFF
--- a/.github/scripts/entrypoint.sh
+++ b/.github/scripts/entrypoint.sh
@@ -169,6 +169,7 @@ fi
 
 # Create the markdown file in .github/changes/
 mkdir -p .github/changes
+chmod -R 777 .github/changes
 
 if [ -n "${GITHUB_REF}" ] && [[ "${GITHUB_REF}" == refs/tags/* ]]; then
   VERSION=$(echo ${GITHUB_REF} | sed 's/refs\/tags\///')


### PR DESCRIPTION

```
# Create the markdown file in .github/changes/
mkdir -p .github/changes
chmod -R 777 .github/changes
```

Summary of Changes
- Added chmod -R 777 .github/changes: This command changes the permissions of the .github/changes directory to allow writing.
- Ensure the script creates the directory and sets the correct permissions before writing the markdown file.